### PR TITLE
Sets ruby version, removes bundler trash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 # the following line to use "https"
 source 'http://rubygems.org'
 
+ruby '2.1.0'
+
 gem "middleman", "~>3.3.0"
 
 # For syntax highlighting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,3 @@ DEPENDENCIES
   ruby18_source_location
   therubyracer
   wdm (~> 0.1.0)
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
These changes, along with the deploy rules being changed from `git clean -d -x -f` to `git clean -d -x -f -e .bundle` should make it possible to deploy automatically from master.